### PR TITLE
for threshold-scientist: don't block compiler UI on glossary load

### DIFF
--- a/source/App.js
+++ b/source/App.js
@@ -711,8 +711,10 @@ export default class App extends Component {
       compileWarnings,
     } = this.state;
 
-    if (glossaryData === null) return null;
-
+    // The glossary download is kicked off in componentDidMount and runs in
+    // parallel. We deliberately do NOT block the UI on it: the scientist can
+    // log in and make selections without it. The glossary is only required to
+    // compile, where Table.js waits for it (showing a "Glossary …" status).
     const steps = [];
 
     const viewingPreviousExperiment =

--- a/source/Table.js
+++ b/source/Table.js
@@ -71,6 +71,9 @@ export default class Table extends Component {
   async handleTable(file) {
     const { user } = this.props;
 
+    // The glossary download is started at app launch and runs in parallel. We
+    // need it to compile, so here we wait for it to finish if it hasn't yet.
+    let waitingForGlossarySwal = false;
     try {
       let shouldFetch = true;
       try {
@@ -88,13 +91,28 @@ export default class Table extends Component {
       }
 
       if (shouldFetch) {
+        // The glossary isn't ready yet; tell the scientist we're waiting on it.
+        Swal.fire({
+          title: "Glossary …",
+          allowOutsideClick: false,
+          allowEscapeKey: false,
+          showConfirmButton: false,
+          willOpen: () => {
+            Swal.showLoading(null);
+          },
+        });
+        waitingForGlossarySwal = true;
         const data = await fetchGlossaryData();
         initGlossary(data);
       }
     } catch (err) {
+      if (waitingForGlossarySwal) Swal.close();
       console.error("Failed to refresh glossary:", err);
       return;
     }
+    // Close the "Glossary …" status before handing off to the resource/compile
+    // flow, which manages its own status dialog.
+    if (waitingForGlossarySwal) Swal.close();
 
     let resolvedResources;
 


### PR DESCRIPTION
The compiler page rendered nothing until the full ~1MB glossary finished downloading (App.js gated render on `glossaryData === null`). Remove that gate so the login/table UI shows immediately; the glossary download still starts at launch and runs in parallel.

The glossary is only required to compile, so Table.handleTable now waits for it there and shows a "Glossary …" status dialog while it loads.